### PR TITLE
Upgrade ejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "keywords": [],
   "dependencies": {
     "async": "^2.5.0",
-    "ejs": "2.3.4",
+    "ejs": "2.5.5",
     "grunt": "1.0.1",
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-coffee": "1.0.0",


### PR DESCRIPTION
In response to [CVE-2017-1000188](https://nvd.nist.gov/vuln/detail/CVE-2017-1000188).
I don't believe this affects `queuel-api` but why not?